### PR TITLE
Add site url with sub dir from GH Pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: The Bash Hackers Wiki
+site_url: https://flokoe.github.io/bash-hackers-wiki/
 
 repo_url: https://github.com/flokoe/bash-hackers-wiki
 repo_name: flokoe/bash-hackers-wiki


### PR DESCRIPTION
This fixes urls on GH Pages but still works locally.

@hansonchar Added site_url property to allow urls work via GH Pages.