### PR TITLE
Fix hyperlinks of markdown pages at depth 3

### DIFF
--- a/docs/commands/builtin/cd.md
+++ b/docs/commands/builtin/cd.md
@@ -12,17 +12,17 @@ The `cd` builtin command is used to change the current working directory
 
 -   to the given directory (`cd DIRECTORY`)
 -   to the previous working directory (`cd -`) as saved in the
-    [OLDPWD](/syntax/shellvars#OLDPWD) shell variable
+    [OLDPWD](../../syntax/shellvars.md#OLDPWD) shell variable
 -   to the user\'s home directory as specified in the
-    [HOME](/syntax/shellvars#HOME) environment variable (when used
+    [HOME](../../syntax/shellvars.md#HOME) environment variable (when used
     without a `DIRECTORY` argument)
 
 The `cd` builtin command searches the directories listed in
-[CDPATH](/syntax/shellvars#CDPATH) for a matching directory.
+[CDPATH](../../syntax/shellvars.md#CDPATH) for a matching directory.
 
 The default behaviour is to follow symbolic links unless the `-P` option
 is given or the shell is configured to do so (see the `-P` option of
-[the set builtin command](/commands/builtin/set)).
+[the set builtin command](../../commands/builtin/set.md)).
 
 ### Options
 
@@ -36,7 +36,7 @@ is given or the shell is configured to do so (see the `-P` option of
 
 -   true if the directory was changed successfully
 -   false if a change to the home directory was requested, but
-    [HOME](/syntax/shellvars#HOME) is unset
+    [HOME](../../syntax/shellvars.md#HOME) is unset
 -   false if anything else goes wrong
 
 ## Examples
@@ -53,7 +53,7 @@ is given or the shell is configured to do so (see the `-P` option of
 
 ## See also
 
--   variable [CDPATH](/syntax/shellvars#CDPATH)
--   variable [HOME](/syntax/shellvars#HOME)
--   variable [OLDPWD](/syntax/shellvars#OLDPWD)
--   the `-P` option of [the set builtin command](/commands/builtin/set)
+-   variable [CDPATH](../../syntax/shellvars.md#CDPATH)
+-   variable [HOME](../../syntax/shellvars.md#HOME)
+-   variable [OLDPWD](../../syntax/shellvars.md#OLDPWD)
+-   the `-P` option of [the set builtin command](../../commands/builtin/set.md)

--- a/docs/commands/builtin/declare.md
+++ b/docs/commands/builtin/declare.md
@@ -176,9 +176,9 @@ for details. ksh93 namerefs are much more powerful than Bash\'s.
 
 ## See also
 
--   [arrays](/syntax/arrays)
--   [readonly](/commands/builtin/readonly)
--   [unset](/commands/builtin/unset)
+-   [arrays](../../syntax/arrays.md)
+-   [readonly](../../commands/builtin/readonly.md)
+-   [unset](../../commands/builtin/unset.md)
 -   [declaration commands](http://austingroupbugs.net/view.php?id=351)
     will change the behavior of certain builtins such as `export` in the
     next version of POSIX.

--- a/docs/commands/builtin/echo.md
+++ b/docs/commands/builtin/echo.md
@@ -8,7 +8,7 @@
 
 `echo` outputs it\'s args to stdout, separated by spaces, followed by a
 newline. The return status is always `0`. If the
-[shopt](/commands/builtin/shopt) option `xpg_echo` is set, Bash
+[shopt](../../commands/builtin/shopt.md) option `xpg_echo` is set, Bash
 dynamically determines whether echo should expand escape characters
 (listed below) by default based on the current platform. `echo` doesn\'t
 interpret `--` as the end of options, and will simply print this string
@@ -69,7 +69,7 @@ if given.
 ```
 -   **Never use options to `echo`! *Ever*!** Any time you feel tempted
     to use `echo -e`, `-n`, or any other special feature of echo, **use
-    [printf](/commands/builtin/printf) instead!** If portability is a
+    [printf](../../commands/builtin/printf.md) instead!** If portability is a
     requirement, you should consider using `printf` *exclusively* and
     just ignore that `echo` even exists. If you must use `echo -e` and
     refuse to use `printf`, it is usually acceptable to use \'\'echo
@@ -81,12 +81,12 @@ if given.
 ```
 -   `ksh93` has a `print` command, which if coding specifically for
     `ksh93` should be preferred over `echo`.
-    [printf](/commands/builtin/printf) still includes most of the
+    [printf](../../commands/builtin/printf.md) still includes most of the
     functionality of both, and should usually be the most preferred
     option.
 
 ## See also
 
--   [printf](/commands/builtin/printf)
+-   [printf](../../commands/builtin/printf.md)
 -   <http://cfajohnson.com/shell/cus-faq.html#Q0b>
 -   <http://www.in-ulm.de/~mascheck/various/echo+printf/>

--- a/docs/commands/builtin/eval.md
+++ b/docs/commands/builtin/eval.md
@@ -18,7 +18,7 @@ a child process.
 ## Examples
 
 In this example, the literal text within the
-[here-document](/syntax/redirection#here_documents) is executed as Bash
+[here-document](../../syntax/redirection.md#here_documents) is executed as Bash
 code exactly as though it were to appear within the script in place of
 the `eval` command below it.
 
@@ -135,10 +135,10 @@ first example above is the same error as the second in all non-Bash
 shells, even those with compound assignment.
 
 In the case of `eval` it isn\'t recommended to use this behavior,
-because unlike e.g. [declare](commands/builtin/declare), the initial
+because unlike e.g. [declare](../../commands/builtin/declare.md), the initial
 expansion is still subject to all expansions including
-[word-splitting](syntax/expansion/wordsplit) and [pathname
-expansion](syntax/expansion/glob).
+[word-splitting](../../syntax/expansion/wordsplit.md) and [pathname
+expansion](../../syntax/expansion/glob.md).
 
      $ ( set -x; touch 'x+=(\[[123]\]=*)' 'x+=([3]=yo)'; eval x+=(*); echo "${x[@]}" )
     + touch 'x+=(\[[123]\]=*)' 'x+=([3]=yo)'
@@ -149,14 +149,14 @@ expansion](syntax/expansion/glob).
     [[123]]=* yo
 
 Other commands known to be affected by compound assignment arguments
-include: [let](commands/builtin/let),
-[declare](commands/builtin/declare),
-[typeset](commands/builtin/typeset), [local](commands/builtin/local),
-[export](commands/builtin/export), and
-[readonly](commands/builtin/readonly). More oddities below show both
+include: [let](../../commands/builtin/let.md),
+[declare](../../commands/builtin/declare.md),
+[typeset](../../commands/builtin/typeset.md), [local](../../commands/builtin/local.md),
+[export](../../commands/builtin/export.md), and
+[readonly](../../commands/builtin/readonly.md). More oddities below show both
 similarities and differences to commands like
-[declare](commands/builtin/declare). The rules for `eval` appear
-identical to those of [let](commands/builtin/let).
+[declare](../../commands/builtin/declare.md). The rules for `eval` appear
+identical to those of [let](../../commands/builtin/let.md).
 
 ## See also
 

--- a/docs/commands/builtin/exec.md
+++ b/docs/commands/builtin/exec.md
@@ -28,7 +28,7 @@ shell without executing any program.
 -   on redirection errors it returns 1, otherwise 0
 -   on exec failures:
     -   a non-interactive shell terminates; if the [shell option
-        execfail](/internals/shell_options#execfail) is set `exec`
+        execfail](../../internals/shell_options.md#execfail) is set `exec`
         returns failure
     -   in an interactive shell, `exec` returns failure
 
@@ -82,4 +82,4 @@ exec >/var/adm/my.log 2>&1
 
 ## See also
 
--   [redirection](/syntax/redirection)
+-   [redirection](../../syntax/redirection.md)

--- a/docs/commands/builtin/exit.md
+++ b/docs/commands/builtin/exit.md
@@ -12,7 +12,7 @@ If `N` is given, the return code to the parent process is set to `N`. If
 not, the returned status the the status of the most recently executed
 command (i.e. `$?`).
 
-A [trap](/commands/builtin/trap) on `EXIT` is executed before the shell
+A [trap](../../commands/builtin/trap.md) on `EXIT` is executed before the shell
 exits, except the executed `exit` command is part of an already running
 trap.
 
@@ -42,5 +42,5 @@ executed the `exit` command, because the shell exits.
 
 ## See also
 
--   [The trap builtin command](/commands/builtin/trap)
--   [The exit status](/dict/terms/exit_status)
+-   [The trap builtin command](../../commands/builtin/trap.md)
+-   [The exit status](../../dict/terms/exit_status.md)

--- a/docs/commands/builtin/export.md
+++ b/docs/commands/builtin/export.md
@@ -49,4 +49,4 @@ Set your default text editor (e.g. SublimeText):
 
 ## See also
 
--   [declare](/commands/builtin/declare)
+-   [declare](../../commands/builtin/declare.md)

--- a/docs/commands/builtin/let.md
+++ b/docs/commands/builtin/let.md
@@ -7,27 +7,27 @@
 ## Description
 
 The `let` builtin command evaluates each supplied word from left to
-right as an [arithmetic expression](/syntax/arith_expr) and returns an
+right as an [arithmetic expression](../../syntax/arith_expr.md) and returns an
 exit code according to the truth value of the rightmost expression.
 
 -   0 (TRUE) when `arg` evaluated to not 0 (arithmetic \"true\")
 -   1 (FALSE) when `arg` evaluated to 0 (arithmetic \"false\")
 
 For this return code mapping, please see [this
-section](/syntax/arith_expr#arithmetic_expressions_and_return_codes).
+section](../../syntax/arith_expr.md#arithmetic_expressions_and_return_codes).
 They work in the same way as `((`.
 
 ## Examples
 
-`let` is very similar to [((](/syntax/ccmd/arithmetic_eval) - the only
+`let` is very similar to [((](../../syntax/ccmd/arithmetic_eval.md) - the only
 difference being `let` is a builtin (simple command), and `((` is a
 compound command. The arguments to `let` are therefore subject to all
 the same expansions and substitutions as any other simple command -
 requiring proper quoting and escaping - whereas the contents of `((`
-aren\'t subject to [word-splitting](/syntax/expansion/wordsplit) or
-[pathname expansion](/syntax/expansion/globs) (almost never desirable
+aren\'t subject to [word-splitting](../../syntax/expansion/wordsplit.md) or
+[pathname expansion](../../syntax/expansion/globs.md) (almost never desirable
 for arithmetic). For this reason, **the [arithmetic compound
-command](/syntax/ccmd/arithmetic_eval) should generally be preferred
+command](../../syntax/ccmd/arithmetic_eval.md) should generally be preferred
 over `let`**.
 
     $ let 'b = a' "(a += 3) + $((a = 1)), b++"
@@ -35,7 +35,7 @@ over `let`**.
     4 - 2 - 0
 
 Is equivalent to the [arithmetic evaluation compound
-command](/syntax/ccmd/arithmetic_eval):
+command](../../syntax/ccmd/arithmetic_eval.md):
 
     $ (( b = a, (a += 3) + $((a = 1)), b++ ))
     $ echo "$a - $b - $?"
@@ -78,14 +78,14 @@ needed.
     ` Aside from differences in supported arithmetic features, this
     should be identical to the Bash/Ksh `let`.
 -   It seems to be a common misunderstanding that `let` has some legacy
-    purpose. Both `let` and [[^1]](syntax/ccmd/arithmetic_eval) were
+    purpose. Both `let` and [[^1]](../../syntax/ccmd/arithmetic_eval.md) were
     ksh88 features and almost identical in terms of portability as
     everything that inherited one also tended to get the other. Don\'t
     choose `let` over `((` expecting it to work in more places.
 -   [expr(1)](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/expr.html#tag_20_42)
     is a command one is likely to come across sooner or later. While it
     is more \"standard\" than `let`, the above should always be
-    preferred. Both [arithmetic expansion](/syntax/arith_expr)s and the
+    preferred. Both [arithmetic expansion](../../syntax/arith_expr.md)s and the
     `[` test operator are specified by POSIX(r) and satisfy almost all
     of expr\'s use-cases. Unlike `let`, `expr` cannot assign directly to
     bash variables but instead returns a result on stdout. `expr` takes
@@ -96,16 +96,16 @@ needed.
     without generating any output other than a return code.
 -   For unknown reasons, `let` is one of the Bash commands with special
     parsing for arguments formatted like compound array assignments.
-    See: [eval](commands/builtin/eval#portability_considerations) for
+    See: [eval](../../commands/builtin/eval.md#portability_considerations) for
     details. There are no known practical uses for this. Parentheses are
     treated as grouping operators and compound assignment is not
     possible by arithmetic expressions.
 
 ## See also
 
--   Internal: [arithmetic expansion](/syntax/expansion/arith)
--   Internal: [arithmetic expressions](/syntax/arith_expr)
+-   Internal: [arithmetic expansion](../../syntax/expansion/arith.md)
+-   Internal: [arithmetic expressions](../../syntax/arith_expr.md)
 -   Internal: [arithmetic evaluation compound
-    command](/syntax/ccmd/arithmetic_eval)
+    command](../../syntax/ccmd/arithmetic_eval.md)
 
 [^1]: \...

--- a/docs/commands/builtin/local.md
+++ b/docs/commands/builtin/local.md
@@ -6,7 +6,7 @@
 
 ## Description
 
-`local` is identical to [declare](/commands/builtin/declare) in every
+`local` is identical to [declare](../../commands/builtin/declare.md) in every
 way, and takes all the same options, with 3 exceptions:
 
 -   Usage outside of a function is an error. Both `declare` and `local`

--- a/docs/commands/builtin/mapfile.md
+++ b/docs/commands/builtin/mapfile.md
@@ -215,7 +215,7 @@ each subsequent 2 iterations. The RETURN trap is unimportant.
 
 ## See also
 
--   [arrays](/syntax/arrays)
--   [read](/commands/builtin/read) - If you don\'t know about this yet,
+-   [arrays](../../syntax/arrays.md)
+-   [read](../../commands/builtin/read.md) - If you don\'t know about this yet,
     why are you reading this page?
 -   <http://mywiki.wooledge.org/BashFAQ/001> - It\'s FAQ 1 for a reason.

--- a/docs/commands/builtin/printf.md
+++ b/docs/commands/builtin/printf.md
@@ -10,7 +10,7 @@ nearly identical for an external command that follows POSIX(r).
 [GNU Awk](http://www.gnu.org/software/gawk/manual/gawk.html#Printf)
 expects a comma after the format string and between each of the
 arguments of a **printf** command. For examples, see: [code
-snippet](printf?&#using_printf_inside_of_awk). \</div\>
+snippet](../../printf?&.md#using_printf_inside_of_awk). \</div\>
 
 Unlike other documentations, I don\'t want to redirect you to the manual
 page for the `printf()` C function family. However, if you\'re more
@@ -68,8 +68,8 @@ this opens up the possibility of an easy code injection vulnerability.
 \...where the echo can of course be replaced with any arbitrary command.
 If you must, either specify a hard-coded format string or use \-- to
 signal the end of options. The exact same issue also applies to
-[read](commands/builtin/read), and a similar one to
-[mapfile](commands/builtin/mapfile), though performing expansions into
+[read](../../commands/builtin/read.md), and a similar one to
+[mapfile](../../commands/builtin/mapfile.md), though performing expansions into
 their arguments is less common. \</note\>
 
 ### Arguments
@@ -93,9 +93,9 @@ interpreted. If fewer format specifiers than arguments are present, then
 number-formats are set to zero, while string-formats are set to null
 (empty).
 
-Take care to avoid [word splitting](/syntax/expansion/wordsplit), as
+Take care to avoid [word splitting](../../syntax/expansion/wordsplit.md), as
 accidentally passing the wrong number of arguments can produce wildly
-different and unexpected results. See [this article](/syntax/words).
+different and unexpected results. See [this article](../../syntax/words.md).
 
 \<note warning\> [**Again, attention:**]{.underline} When a numerical
 format expects a number, the internal `printf`-command will use the
@@ -234,7 +234,7 @@ associated with a `%b` format:
     (POSIX specifies up to three).
 
 These are also respects in which `%b` differs from the escapes used by
-[\$\'\...\'](syntax/quoting#ansi_c_like_strings) style quoting.
+[\$\'\...\'](../../syntax/quoting.md#ansi_c_like_strings) style quoting.
 
 ## Examples
 
@@ -447,7 +447,7 @@ fmt++;
 
 -   The optional Bash loadable `print` may be useful for ksh
     compatibility and to overcome some of
-    [echo](commands/builtin/echo)\'s portability pitfalls. Bash, ksh93,
+    [echo](../../commands/builtin/echo.md)\'s portability pitfalls. Bash, ksh93,
     and zsh\'s `print` have an `-f` option which takes a `printf` format
     string and applies it to the remaining arguments. Bash lists the
     synopsis as:
@@ -461,7 +461,7 @@ fmt++;
 ```
 -   Assigning to variables: The `printf -v` way is slightly different to
     the way using command-substitution. [Command
-    substitution](/syntax/expansion/cmdsubst) removes trailing newlines
+    substitution](../../syntax/expansion/cmdsubst.md) removes trailing newlines
     before substituting the text, `printf -v` preserves all output.
 
 ## See also
@@ -471,6 +471,6 @@ fmt++;
     and [printf()
     function](http://pubs.opengroup.org/onlinepubs/9699919799/functions/printf.html)
 -   [Code snip: Print a horizontal
-    line](/snipplets/print_horizontal_line) uses some `printf` examples
+    line](../../snipplets/print_horizontal_line.md) uses some `printf` examples
 -   [Greg\'s BashFAQ 18: How can I use numbers with leading zeros in a
     loop, e.g., 01, 02?](BashFAQ>018)

--- a/docs/commands/builtin/read.md
+++ b/docs/commands/builtin/read.md
@@ -16,13 +16,13 @@ Since Bash 4.3-alpha, `read` skips any `NUL` (ASCII code 0) characters
 in input.
 
 If `<NAME...>` is given, the line is word-split using
-[IFS](/syntax/shellvars#IFS) variable, and every word is assigned to one
+[IFS](../../syntax/shellvars.md#IFS) variable, and every word is assigned to one
 `<NAME>`. The remaining words are all assigned to the last `<NAME>` if
 more words than variable names are present.
 
 \<WRAP center round info 90%\> If no `<NAME>` is given, the whole line
 read (without performing word-splitting!) is assigned to the shell
-variable [REPLY](/syntax/shellvars#REPLY). Then, `REPLY` really contains
+variable [REPLY](../../syntax/shellvars.md#REPLY). Then, `REPLY` really contains
 the line as it was read, without stripping pre- and postfix spaces and
 other things!
 
@@ -33,7 +33,7 @@ other things!
 \</WRAP\>
 
 If a timeout is given, or if the shell variable
-[TMOUT](/syntax/shellvars#TMOUT) is set, it is counted from initially
+[TMOUT](../../syntax/shellvars.md#TMOUT) is set, it is counted from initially
 waiting for input until the completion of input (i.e. until the complete
 line is read). That means the timeout can occur during input, too.
 
@@ -64,7 +64,7 @@ Of course it\'s valid to set individual array elements without using
 \<WRAP center round important 90%\>
 
 Reading into array elements using the syntax above **may cause [pathname
-expansion](/syntax/expansion/globs) to occur**.
+expansion](../../syntax/expansion/globs.md) to occur**.
 
 Example: You are in a directory with a file named `x1`, and you want to
 read into an array `x`, index `1` with
@@ -172,7 +172,7 @@ Take care that you cannot use a pipe:
 Why? because the commands of the pipe run in subshells that cannot
 modify the parent shell. As a result, the variables `col1`, `col2` and
 `col3` of the parent shell are not modified (see article:
-[processtree](/scripting/processtree)).
+[processtree](../../scripting/processtree.md)).
 
 If the variable has more fields than there are variables, the last
 variable get the remaining of the line:
@@ -184,7 +184,7 @@ variable get the remaining of the line:
 
 By default reads separates the line in fields using spaces or tabs. You
 can modify this using the *special variable*
-[IFS](/syntax/shellvars#IFS), the Internal Field Separator.
+[IFS](../../syntax/shellvars.md#IFS), the Internal Field Separator.
 
     IFS=":" read -r col1 col2 <<< "hello:world"
     printf "col1: %s col2: %s\n" "$col1" "$col2"
@@ -264,6 +264,6 @@ date/time string are recognized correctly.
 
 ## See also
 
--   Internal: [The printf builtin command](/commands/builtin/printf)
+-   Internal: [The printf builtin command](../../commands/builtin/printf.md)
 
 [^1]: fixed in 4.2-rc1

--- a/docs/commands/builtin/readonly.md
+++ b/docs/commands/builtin/readonly.md
@@ -41,5 +41,5 @@ An argument of `--` disables further option processing.
 
 ## See also
 
--   [declare](/commands/builtin/declare)
--   [unset](/commands/builtin/unset)
+-   [declare](../../commands/builtin/declare.md)
+-   [unset](../../commands/builtin/unset.md)

--- a/docs/commands/builtin/return.md
+++ b/docs/commands/builtin/return.md
@@ -31,5 +31,5 @@ comes back, there was a problem in doing the return.
 
 ## See also
 
--   [The exit builtin command](/commands/builtin/exit)
--   [The exit status](/dict/terms/exit_status)
+-   [The exit builtin command](../../commands/builtin/exit.md)
+-   [The exit status](../../dict/terms/exit_status.md)

--- a/docs/commands/builtin/set.md
+++ b/docs/commands/builtin/set.md
@@ -11,7 +11,7 @@ FIXME incomplete - text, examples, maybe extended description
 `set` is primarily made to
 
 -   set the positional parameters (see [handling positional
-    parameters](/scripting/posparams)) to `<POSPARAMS>`
+    parameters](../../scripting/posparams.md)) to `<POSPARAMS>`
 -   set shell attributes with short options (see below)
 -   set shell attributes with long option names (see below)
 
@@ -29,7 +29,7 @@ set flags (true for most commands on UNIX(r)).
   `-a`   `allexport`                                                Automatically mark new and altered variables to be exported to subsequent environments.
   `-b`   `notify`                                                   Don\'t wait for the next prompt to print when showing the reports for a terminated background job (only with job control)
   `-e`   `errexit`                                                  When set, the shell exits when a simple command in a command list exits non-zero (`FALSE`). This is not done in situations, where the exit code is already checked (`if`, `while`, `until`, `||`, `&&`)
-  `-f`   `noglob`                                                   Disable [pathname expansion](/syntax/expansion/globs) (globbing)
+  `-f`   `noglob`                                                   Disable [pathname expansion](../../syntax/expansion/globs.md) (globbing)
   `-h`   `hashall`                                                  Remembers the location of commands when they\'re called (hashing). Enabled by default.
   `-k`   `keyword`                                                  Allows to place environment-assignments everywhere in the commandline, not only infront of the called command.
   `-m`   `monitor`                                                  **Monitor mode**. With job control, a short descriptive line is printed when a backgroud job ends. Default is \"on\" for interactive shells (with job control).
@@ -40,8 +40,8 @@ set flags (true for most commands on UNIX(r)).
   `-u`   `nounset`                                                  Treat unset variables as an error when performing parameter expansion. Non-interactive shells exit on this error.
   `-v`   `verbose`                                                  Print shell input lines as they are read - useful for debugging.
   `-x`   `xtrace`                                                   Print commands just before execution - with all expansions and substitutions done, and words marked - useful for debugging.
-  `-B`   `braceexpand`                                              The shell performs [brace expansion](/syntax/expansion/brace) This is on by default.
-  `-C`   \<BOOKMARK:tag_noclobber\>`noclobber`                      Don\'t overwrite files on redirection operations. You can override that by specifying the `>|` redirection operator when needed. See [redirection](/syntax/redirection)
+  `-B`   `braceexpand`                                              The shell performs [brace expansion](../../syntax/expansion/brace.md) This is on by default.
+  `-C`   \<BOOKMARK:tag_noclobber\>`noclobber`                      Don\'t overwrite files on redirection operations. You can override that by specifying the `>|` redirection operator when needed. See [redirection](../../syntax/redirection.md)
   `-E`   `errtrace`                                                 `ERR`-traps are inherited by by shell functions, command substitutions, and commands executed in a subshell environment.
   `-H`   `histexpand`                                               Enable `!`-style history expansion. Defaults to `on` for interactive shells.
   `-P`   `physical`                                                 Don\'t follow symlinks when changing directories - use the physical filesystem structure.
@@ -51,7 +51,7 @@ set flags (true for most commands on UNIX(r)).
          Long options usable with `-o` without a short equivalent   
          `emacs`                                                    Use an emacs-style command line editing interface. This is enabled by default when the shell is interactive, unless the shell is started with `--noediting` option.
          `history`                                                  If set, command historization is done (enabled by default on interactive shells)
-         `ignoreeof`                                                The effect is as if the shell command `IGNOREEOF=10` had been executed. See [shell variables](/syntax/shellvars).
+         `ignoreeof`                                                The effect is as if the shell command `IGNOREEOF=10` had been executed. See [shell variables](../../syntax/shellvars.md).
          `nolog`                                                    **(currently ignored)**
          `pipefail`                                                 If set, the exit code from a pipeline is different from the normal (\"last command in pipeline\") behaviour: `TRUE` when no command failed, `FALSE` when something failed (code of the rightmost command that failed)
          `posix`                                                    When set, Bash runs in POSIX mode.
@@ -78,4 +78,4 @@ naturally.
 
 ## See also
 
--   Internal: [The shopt builtin command](/commands/builtin/shopt)
+-   Internal: [The shopt builtin command](../../commands/builtin/shopt.md)

--- a/docs/commands/builtin/shift.md
+++ b/docs/commands/builtin/shift.md
@@ -28,7 +28,7 @@ When you use `shift 1`, they will be changed to:
   2   a
   3   test
 
-The [special parameter](/syntax/shellvars#special_parameters) `$#` will
+The [special parameter](../../syntax/shellvars.md#special_parameters) `$#` will
 reflect the final number of positional parameters.
 
 If the number given is 0, no changes are made to the positional
@@ -56,13 +56,13 @@ There are no options.
     than the number of positional parameters. **POSIX does not require
     that behavior**. Bash (even in POSIX mode) and Zsh return 1 when
     there are no args, and no error output is produced unless the
-    [shift_verbose](internals/shell_options#shift_verbose)
-    [shopt](commands/builtin/shopt) option is enabled. Ksh93, pdksh,
+    [shift_verbose](../../internals/shell_options.md#shift_verbose)
+    [shopt](../../commands/builtin/shopt.md) option is enabled. Ksh93, pdksh,
     posh, mksh, and dash, all throw useless fatal shell
     errors.`$ dash -c 'f() { if shift; then echo "$1"; else echo "no args"; fi; }; f'
     dash: 1: shift: can't shift that many
     ` In most shells, you can work around this problem using the
-    [command](/commands/builtin/command) builtin to suppress fatal
+    [command](../../commands/builtin/command.md) builtin to suppress fatal
     errors caused by *special builtins*. \<code\> \$ dash -c \'f() { if
     command shift 2\>/dev/null; then echo \"\$1\"; else echo \"no
     args\"; fi; }; f\'

--- a/docs/commands/builtin/shopt.md
+++ b/docs/commands/builtin/shopt.md
@@ -1,6 +1,6 @@
 # The shopt builtin command
 
-The `shopt` builtin manages [shell options](/internals/shell_options), a
+The `shopt` builtin manages [shell options](../../internals/shell_options.md), a
 set of boolean (`on`/`off`) configuration variables that control the
 behaviour of the shell.
 
@@ -11,13 +11,13 @@ behaviour of the shell.
 ## Description
 
 Note: Some of these options and other shell options can also be set with
-[the set builtin](/commands/builtin/set).
+[the set builtin](../../commands/builtin/set.md).
 
 ### Options
 
   Option   Description
   -------- -----------------------------------------------------------------------------------------------------------------------------
-  `-o`     Restrict the values of `<OPTNAME...>` to only those also known by [the set builtin](/commands/builtin/set)
+  `-o`     Restrict the values of `<OPTNAME...>` to only those also known by [the set builtin](../../commands/builtin/set.md)
   `-p`     Print all shell options and their current value. **Default**.
   `-q`     Quiet mode. Set exit code if named option is set. For multiple options: `TRUE` if all options are set, `FALSE` otherwise
   `-s`     Enable ([s]{.underline}et) the shell options named by `<OPTNAME...>` or list all *enabled* options if no names are given
@@ -47,5 +47,5 @@ The `shopt` command is not portable accross different shells.
 
 ## See also
 
--   Internal: [The set builtin command](/commands/builtin/set)
--   Internal: [List of shell options](/internals/shell_options)
+-   Internal: [The set builtin command](../../commands/builtin/set.md)
+-   Internal: [List of shell options](../../internals/shell_options.md)

--- a/docs/commands/builtin/trap.md
+++ b/docs/commands/builtin/trap.md
@@ -34,7 +34,7 @@ Special events
   `EXIT`     0      executed on shell exit
   `DEBUG`           executed before every simple command
   `RETURN`          executed when a shell function or a sourced code finishes executing
-  `ERR`             executed each time a command\'s failure would cause the shell to exit when the [`-e` option (`errexit`)](/commands/builtin/set) is enabled
+  `ERR`             executed each time a command\'s failure would cause the shell to exit when the [`-e` option (`errexit`)](../../commands/builtin/set.md) is enabled
 
 ### Options
 
@@ -68,5 +68,5 @@ Special events
 
 ## See also
 
--   [the set command](/commands/builtin/set) for the `-e` (`errexit`)
+-   [the set command](../../commands/builtin/set.md) for the `-e` (`errexit`)
     option

--- a/docs/commands/builtin/unset.md
+++ b/docs/commands/builtin/unset.md
@@ -175,7 +175,7 @@ using `unset`. Also, I prefer it as a matter of style.
 
 ## See also
 
--   [declare](/commands/builtin/declare)
--   [unset](/commands/builtin/unset)
+-   [declare](../../commands/builtin/declare.md)
+-   [unset](../../commands/builtin/unset.md)
 -   [POSIX `unset`
     utility](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_29)

--- a/docs/syntax/ccmd/arithmetic_eval.md
+++ b/docs/syntax/ccmd/arithmetic_eval.md
@@ -6,17 +6,17 @@
 
 ## Description
 
-This command evaluates the [arithmetic expression](/syntax/arith_expr)
+This command evaluates the [arithmetic expression](../../syntax/arith_expr.md)
 `<EXPRESSION>`.
 
 If the expression evaluates to 0 then the exit code of the expression is
 set to 1 (`FALSE`). If the expression evaluates to something else than
 0, then the exit code of the expression is set to 0 (`TRUE`). For this
 return code mapping, please see [this
-section](/syntax/arith_expr#arithmetic_expressions_and_return_codes).
+section](../../syntax/arith_expr.md#arithmetic_expressions_and_return_codes).
 
 The functionality basically is equivalent to what the [`let` builtin
-command](/commands/builtin/let) does. The arithmetic evaluation compound
+command](../../commands/builtin/let.md) does. The arithmetic evaluation compound
 command should be preferred.
 
 ## Examples
@@ -25,6 +25,6 @@ command should be preferred.
 
 ## See also
 
--   Internal: [arithmetic expressions](/syntax/arith_expr)
--   Internal: [arithmetic expansion](/syntax/expansion/arith)
--   Internal: [The `let` builtin command](/commands/builtin/let)
+-   Internal: [arithmetic expressions](../../syntax/arith_expr.md)
+-   Internal: [arithmetic expansion](../../syntax/expansion/arith.md)
+-   Internal: [The `let` builtin command](../../commands/builtin/let.md)

--- a/docs/syntax/ccmd/c_for.md
+++ b/docs/syntax/ccmd/c_for.md
@@ -19,7 +19,7 @@
 ## Description
 
 The C-style for-loop is a [compound
-command](syntax/basicgrammar#compound_commands) derived from the
+command](../../syntax/basicgrammar.md#compound_commands) derived from the
 equivalent ksh88 feature, which is in turn derived from the C \"for\"
 keyword. Its purpose is to provide a convenient way to evaluate
 arithmetic expressions in a loop, plus initialize any required
@@ -27,9 +27,9 @@ arithmetic variables. It is one of the main \"loop with a counter\"
 mechanisms available in the language.
 
 The `((;;))` syntax at the top of the loop is not an ordinary
-[arithmetic compound command](syntax/ccmd/arithmetic_eval), but is part
+[arithmetic compound command](../../syntax/ccmd/arithmetic_eval.md), but is part
 of the C-style for-loop\'s own syntax. The three sections separated by
-semicolons are [arithmetic expression](/syntax/arith_expr) contexts.
+semicolons are [arithmetic expression](../../syntax/arith_expr.md) contexts.
 Each time one of the sections is to be evaluated, the section is first
 processed for: brace, parameter, command, arithmetic, and process
 substitution/expansion as usual for arithmetic contexts. When the loop
@@ -51,16 +51,16 @@ behaves as if it would be 1 (**TRUE** in arithmetic context).
 :!: Like all loops (Both types of `for`-loop, `while` and `until`), this
 loop can be:
 
--   Terminated (broken) by the [break](commands/builtin/continuebreak)
+-   Terminated (broken) by the [break](../../commands/builtin/continuebreak.md)
     builtin, optionally as `break N` to break out of `N` levels of
     nested loops.
 -   Forced immediately to the next iteration using the
-    [continue](commands/builtin/continuebreak) builtin, optionally as
+    [continue](../../commands/builtin/continuebreak.md) builtin, optionally as
     the `continue N` analog to `break N`.
 
-The equivalent construct using a [while loop](syntax/ccmd/while_loop)
+The equivalent construct using a [while loop](../../syntax/ccmd/while_loop.md)
 and the [arithmetic expression compound
-command](/syntax/ccmd/arithmetic_eval) would be structured as:
+command](../../syntax/ccmd/arithmetic_eval.md) would be structured as:
 
     (( <EXPR1> ))
     while (( <EXPR2> )); do
@@ -70,7 +70,7 @@ command](/syntax/ccmd/arithmetic_eval) would be structured as:
 
 The equivalent `while` construct isn\'t exactly the same, because both,
 the `for` and the `while` loop behave differently in case you use the
-[continue](commands/builtin/continuebreak) command.
+[continue](../../commands/builtin/continuebreak.md) command.
 
 ### Alternate syntax
 
@@ -87,7 +87,7 @@ This syntax is **not documented** and shouldn\'t be used. I found the
 parser definitions for it in 1.x code, and in modern 4.x code. My guess
 is that it\'s there for compatibility reasons. Unlike the other
 aforementioned shells, Bash does not support the analogous syntax for
-[case..esac](syntax/ccmd/case#portability_considerations).
+[case..esac](../../syntax/ccmd/case.md#portability_considerations).
 
 ### Return status
 
@@ -234,6 +234,6 @@ variables.
 
 ## See also
 
--   Internal: [Arithmetic expressions](/syntax/arith_expr)
--   Internal: [The classic for-loop](/syntax/ccmd/classic_for)
--   Internal: [The while-loop](/syntax/ccmd/while_loop)
+-   Internal: [Arithmetic expressions](../../syntax/arith_expr.md)
+-   Internal: [The classic for-loop](../../syntax/ccmd/classic_for.md)
+-   Internal: [The while-loop](../../syntax/ccmd/while_loop.md)

--- a/docs/syntax/ccmd/case.md
+++ b/docs/syntax/ccmd/case.md
@@ -13,9 +13,9 @@
 ## Description
 
 The `case`-statement can execute commands based on a [pattern
-matching](/syntax/pattern) decision. The word `<WORD>` is matched
+matching](../../syntax/pattern.md) decision. The word `<WORD>` is matched
 against every pattern `<PATTERNn>` and on a match, the associated
-[list](/syntax/basicgrammar#lists) `<LISTn>` is executed. Every
+[list](../../syntax/basicgrammar.md#lists) `<LISTn>` is executed. Every
 commandlist is terminated by `;;`. This rule is optional for the very
 last commandlist (i.e., you can omit the `;;` before the `esac`). Every
 `<PATTERNn>` is separated from it\'s associated `<LISTn>` by a `)`, and
@@ -43,7 +43,7 @@ done**, which means you can leave expansions unquoted without problems:
     esac
 
 This is similar to the behavior of the [conditional expression command
-(\"new test command\")](/syntax/ccmd/conditional_expression) (also no
+(\"new test command\")](../../syntax/ccmd/conditional_expression.md) (also no
 word splitting for expansions).
 
 Unlike the C-case-statement, only the matching list and nothing else is
@@ -152,7 +152,7 @@ f a b c
 -   ksh93, mksh, zsh, and posh support a historical syntax where open
     and close braces may be used in place of `in` and `esac`:
     `case word { x) ...; };`. This is similar to the alternate form Bash
-    supports for its [for loops](syntax/ccmd/classic_for), but Bash
+    supports for its [for loops](../../syntax/ccmd/classic_for.md), but Bash
     doesn\'t support this syntax for `case..esac`.
 
 ## See also

--- a/docs/syntax/ccmd/classic_for.md
+++ b/docs/syntax/ccmd/classic_for.md
@@ -66,7 +66,7 @@ The return status is the one of the last command executed in `<LIST>` or
 
 ### Iterate over array elements
 
-With some array syntax (see [arrays](/syntax/arrays)) you can easily
+With some array syntax (see [arrays](../../syntax/arrays.md)) you can easily
 \"feed\" the for-loop to iterate over all elements in an array (by
 mass-expanding all elements):
 
@@ -88,7 +88,7 @@ done
 ### List positional parameters
 
 You can use this
-[function](/syntax/basicgrammar#shell_function_definitions) to test how
+[function](../../syntax/basicgrammar.md#shell_function_definitions) to test how
 arguments to a command will be interpreted and parsed, and finally used:
 
 ``` bash
@@ -138,7 +138,7 @@ done
 This is just an example. In *general*
 
 -   it\'s not a good idea to parse `ls(1)` output
--   the [while loop](/syntax/ccmd/while_loop) (using the `read` command)
+-   the [while loop](../../syntax/ccmd/while_loop.md) (using the `read` command)
     is a better joice to iterate over lines
 
 ### Nested for-loops
@@ -157,7 +157,7 @@ done
 ### Loop over a number range
 
 Beginning in Bash 4, you can also use \"sequence expression\" form of
-[brace expansion](/syntax/expansion/brace) syntax when looping over
+[brace expansion](../../syntax/expansion/brace.md) syntax when looping over
 numbers, and this form does not create leading zeroes unless you ask for
 them:
 
@@ -183,6 +183,6 @@ expands to a huge list.
 
 ## See also
 
--   [c_for](/syntax/ccmd/c_for)
+-   [c_for](../../syntax/ccmd/c_for.md)
 
 [^1]: <http://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xcu_chap02.html#tag_23_02_09_12>

--- a/docs/syntax/ccmd/conditional_expression.md
+++ b/docs/syntax/ccmd/conditional_expression.md
@@ -7,13 +7,13 @@
 ## Description
 
 The conditional expression is meant as the modern variant of the
-[classic test command](/commands/classictest). Since it is **not** a
+[classic test command](../../commands/classictest.md). Since it is **not** a
 normal command, Bash doesn\'t need to apply the normal commandline
 parsing rules like recognizing `&&` as [command
-list](/syntax/basicgrammar#lists) operator.
+list](../../syntax/basicgrammar.md#lists) operator.
 
 The testing features basically are the same (see the lists for [classic
-test command](/commands/classictest)), with some additions and
+test command](../../commands/classictest.md)), with some additions and
 extensions.
 
   -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -34,14 +34,14 @@ extensions.
 
   `<STRING> =~ <ERE>`                                                  `<STRING>` is checked against the [extended regular expression](https://en.wikipedia.org/wiki/Regular_expression#POSIX_extended) `<ERE>` - `TRUE` on a match
 
-  See the [classic test operators](/commands/classictest#file_tests)   Do **not** use the `test`-typical operators `-a` and `-o` for AND and OR.
+  See the [classic test operators](../../commands/classictest.md#file_tests)   Do **not** use the `test`-typical operators `-a` and `-o` for AND and OR.
 
-  See also [arithmetic comparisons](/syntax/arith_expr#comparisons)    Using `(( <EXPRESSION> ))`, the [arithmetic expression compound command](/syntax/ccmd/arithmetic_eval)
+  See also [arithmetic comparisons](../../syntax/arith_expr.md#comparisons)    Using `(( <EXPRESSION> ))`, the [arithmetic expression compound command](../../syntax/ccmd/arithmetic_eval.md)
   -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 When the `==` and `!=` operators are used, the string to the right of
 the operator is considered a pattern and matched according to the rules
-of [Pattern Matching](/syntax/pattern). If the shell option
+of [Pattern Matching](../../syntax/pattern.md). If the shell option
 `nocasematch` is enabled, the match is performed without regard to the
 case of alphabetic characters.
 
@@ -65,8 +65,8 @@ operators `&&` and `||`.
 
 ### Word splitting
 
-[Word splitting](/syntax/expansion/wordsplit) and [pathname
-expansion](/syntax/expansion/globs) are not performed in the expression
+[Word splitting](../../syntax/expansion/wordsplit.md) and [pathname
+expansion](../../syntax/expansion/globs.md) are not performed in the expression
 you give. That means, a variable containing spaces can be used without
 quoting:
 
@@ -78,7 +78,7 @@ quoting:
       echo "Sorry, no match :-("
     fi
 
-Compare that to the [classic test command](/commands/classictest), where
+Compare that to the [classic test command](../../commands/classictest.md), where
 word splitting is done (because it\'s a normal command, not something
 special):
 
@@ -128,7 +128,7 @@ regular expressions.
 
 The interpretation of quoted regular expression special characters can
 be influenced by setting the `compat31` and `compat32` shell options
-(`compat*` in general). See [shell_options](/internals/shell_options).
+(`compat*` in general). See [shell_options](../../internals/shell_options.md).
 
 #### The special BASH_REMATCH array variable
 
@@ -139,7 +139,7 @@ The element with index 0 is the portion of the string matching the
 entire regular expression. The element with index n is the portion of
 the string matching the nth parenthesized subexpression.
 
-See [BASH_REMATCH](syntax/shellvars#bash_rematch).
+See [BASH_REMATCH](../../syntax/shellvars.md#bash_rematch).
 
 Example:
 
@@ -203,9 +203,9 @@ both contains whitespace and is not the result of an expansion.
 
 ## See also
 
--   Internal: [pattern matching language](/syntax/pattern)
--   Internal: [the classic test command](/commands/classictest)
--   Internal: [the if-clause](/syntax/ccmd/if_clause)
+-   Internal: [pattern matching language](../../syntax/pattern.md)
+-   Internal: [the classic test command](../../commands/classictest.md)
+-   Internal: [the if-clause](../../syntax/ccmd/if_clause.md)
 -   [What is the difference between test, \[ and \[\[
     ?](http://mywiki.wooledge.org/BashFAQ/031) - BashFAQ 31 - Greg\'s
     wiki.

--- a/docs/syntax/ccmd/grouping_plain.md
+++ b/docs/syntax/ccmd/grouping_plain.md
@@ -10,14 +10,14 @@
 
 ## Description
 
-The [list](/syntax/basicgrammar#lists) `<LIST>` is simply executed in
+The [list](../../syntax/basicgrammar.md#lists) `<LIST>` is simply executed in
 the **current** shell environment. The list must be terminated with a
 **newline** or **semicolon**. For parsing reasons, the curly braces must
 be separated from `<LIST>` by a **semicolon** and **blanks** if they\'re
 in the same line! [^1][^2]
 
 This is known as a **group command**. The return status is the [exit
-status (exit code)](/scripting/basics#exit_codes) of the list.
+status (exit code)](../../scripting/basics.md#exit_codes) of the list.
 
 The input and output **filedescriptors** are cumulative:
 
@@ -30,7 +30,7 @@ The input and output **filedescriptors** are cumulative:
     } >output.txt
 
 This compound command also usually is the body of a [function
-definition](/syntax/basicgrammar#shell_function_definitions), though not
+definition](../../syntax/basicgrammar.md#shell_function_definitions), though not
 the only compound command that\'s valid there:
 
     print_help() {

--- a/docs/syntax/ccmd/grouping_subshell.md
+++ b/docs/syntax/ccmd/grouping_subshell.md
@@ -6,7 +6,7 @@
 
 ## Description
 
-The [list](/syntax/basicgrammar#lists) `<LIST>` is executed in a
+The [list](../../syntax/basicgrammar.md#lists) `<LIST>` is executed in a
 separate shell - a subprocess. No changes to the environment (variables
 etc\...) are reflected in the \"main shell\".
 
@@ -31,5 +31,5 @@ echo "$PWD" # Still in the original directory.
 
 ## See also
 
--   [grouping commands](/syntax/ccmd/grouping_plain)
+-   [grouping commands](../../syntax/ccmd/grouping_plain.md)
 -   [Subshells on Greycat\'s wiki](http://mywiki.wooledge.org/SubShell)

--- a/docs/syntax/ccmd/if_clause.md
+++ b/docs/syntax/ccmd/if_clause.md
@@ -26,10 +26,10 @@ The `if`-clause can control the script\'s flow (what\'s executed) by
 looking at the exit codes of other commands.
 
 All commandsets `<LIST>` are interpreted as [command
-lists](/syntax/basicgrammar#lists), thus they can contain the whole
-palette from [simple commands](/syntax/basicgrammar#simple_commands)
-over [pipelines](/syntax/basicgrammar#pipelines) to [compound
-commands](/syntax/basicgrammar#compound_commands) (and their
+lists](../../syntax/basicgrammar.md#lists), thus they can contain the whole
+palette from [simple commands](../../syntax/basicgrammar.md#simple_commands)
+over [pipelines](../../syntax/basicgrammar.md#pipelines) to [compound
+commands](../../syntax/basicgrammar.md#compound_commands) (and their
 combination) as condition.
 
 ### Operation
@@ -88,4 +88,4 @@ example above (multiple commands):
 
 ## See also
 
--   Internal: [the classic test command](/commands/classictest)
+-   Internal: [the classic test command](../../commands/classictest.md)

--- a/docs/syntax/ccmd/intro.md
+++ b/docs/syntax/ccmd/intro.md
@@ -2,34 +2,34 @@
 
 The main part of Bash\'s syntax are the so-called **compound commands**.
 They\'re called like that because they use \"real\" commands ([simple
-commands](/syntax/basicgrammar#simple_commands) or
-[lists](/syntax/basicgrammar#lists)) and knit some intelligence around
+commands](../../syntax/basicgrammar.md#simple_commands) or
+[lists](../../syntax/basicgrammar.md#lists)) and knit some intelligence around
 them. That is what the essential \"Bash language\" is made of.
 
 ## Command grouping
 
--   grouping: [command grouping](grouping_plain)
--   grouping again: [command grouping in a subshell](grouping_subshell)
+-   grouping: [command grouping](../../grouping_plain.md)
+-   grouping again: [command grouping in a subshell](../../grouping_subshell.md)
 
 ## Conditional reactions
 
 Note that conditionals can also be scripted using
-[list](/syntax/basicgrammar#lists), which are syntax elements, not
+[list](../../syntax/basicgrammar.md#lists), which are syntax elements, not
 commands.
 
 -   the \"new\" test command: [conditional
-    expression](conditional_expression)
--   if-clause: [conditional branching](if_clause)
--   case statement: [pattern-based branching](case)
+    expression](../../conditional_expression.md)
+-   if-clause: [conditional branching](../../if_clause.md)
+-   case statement: [pattern-based branching](../../case.md)
 
 ## Loops
 
--   [classic for-loop](classic_for)
--   [C-style for-loop](c_for)
--   [while loop](while_loop)
--   [until loop](until_loop)
+-   [classic for-loop](../../classic_for.md)
+-   [C-style for-loop](../../c_for.md)
+-   [while loop](../../while_loop.md)
+-   [until loop](../../until_loop.md)
 
 ## Misc
 
--   math: [arithmetic evaluation](arithmetic_eval)
--   menus: [user selections](user_select)
+-   math: [arithmetic evaluation](../../arithmetic_eval.md)
+-   menus: [user selections](../../user_select.md)

--- a/docs/syntax/ccmd/until_loop.md
+++ b/docs/syntax/ccmd/until_loop.md
@@ -9,12 +9,12 @@
 ## Description
 
 The until-loop is relatively simple in what it does: it executes the
-[command list](/syntax/basicgrammar#lists) `<LIST1>` and if the exit
+[command list](../../syntax/basicgrammar.md#lists) `<LIST1>` and if the exit
 code of it was **not** 0 (FALSE) it executes `<LIST2>`. This happens
 again and again until `<LIST1>` returns TRUE.
 
 This is exactly the opposite of the [while
-loop](/syntax/ccmd/while_loop).
+loop](../../syntax/ccmd/while_loop.md).
 
 :!: Like all loops (both `for`-loops, `while` and `until`), this loop
 can be
@@ -35,4 +35,4 @@ or `0` (`TRUE`) if none was executed.
 
 ## See also
 
--   Internal: [The while loop](/syntax/ccmd/while_loop)
+-   Internal: [The while loop](../../syntax/ccmd/while_loop.md)

--- a/docs/syntax/ccmd/user_select.md
+++ b/docs/syntax/ccmd/user_select.md
@@ -27,7 +27,7 @@
 This compound command provides a kind of menu. The user is prompted with
 a *numbered list* of the given words, and is asked to input the index
 number of the word. If a word was selected, the variable `<NAME>` is set
-to this word, and the [list](/syntax/basicgrammar#lists) `<LIST>` is
+to this word, and the [list](../../syntax/basicgrammar.md#lists) `<LIST>` is
 executed.
 
 If no `in <WORDS>` is given, then the positional parameters are taken as

--- a/docs/syntax/ccmd/while_loop.md
+++ b/docs/syntax/ccmd/while_loop.md
@@ -9,12 +9,12 @@
 ## Description
 
 The while-loop is relatively simple in what it does: it executes the
-[command list](/syntax/basicgrammar#lists) `<LIST1>` and if the exit
+[command list](../../syntax/basicgrammar.md#lists) `<LIST1>` and if the exit
 code of it was 0 (TRUE) it executes `<LIST2>`. This happens again and
 again until `<LIST1>` returns FALSE.
 
 This is exactly the opposite of the [until
-loop](/syntax/ccmd/until_loop).
+loop](../../syntax/ccmd/until_loop.md).
 
 :!: Like all loops (both `for`-loops, `while` and `until`), this loop
 can be
@@ -35,7 +35,7 @@ or `0` (`TRUE`) if none was executed.
 
 ## See also
 
--   Internal: [The until loop](/syntax/ccmd/until_loop)
+-   Internal: [The until loop](../../syntax/ccmd/until_loop.md)
 -   Internal: [code examples of the read builtin
-    command](/commands/builtin/read#code_examples) to see how you can
+    command](../../commands/builtin/read.md#code_examples) to see how you can
     loop over lines

--- a/docs/syntax/expansion/arith.md
+++ b/docs/syntax/expansion/arith.md
@@ -4,7 +4,7 @@
 
     $[ <EXPRESSION> ]
 
-The [arithmetic expression](/syntax/arith_expr) `<EXPRESSION>` is
+The [arithmetic expression](../../syntax/arith_expr.md) `<EXPRESSION>` is
 evaluated and expands to the result. The output of the arithmetic
 expansion is guaranteed to be one word and a digit in Bash.
 
@@ -29,7 +29,7 @@ function printSum {
 **Note** that in Bash you don\'t need the arithmetic expansion to check
 for the boolean value of an arithmetic expression. This can be done
 using the [arithmetic evaluation compound
-command](/syntax/ccmd/arithmetic_eval):
+command](../../syntax/ccmd/arithmetic_eval.md):
 
 ``` bash
 printf %s 'Enter a number: ' >&2
@@ -66,10 +66,10 @@ echo $(($x[0]))   # Error. This expands to $((1[0])), an invalid expression.
 
 ## See also
 
--   [arithmetic expressions](/syntax/arith_expr)
+-   [arithmetic expressions](../../syntax/arith_expr.md)
 -   [arithmetic evaluation compound
-    command](/syntax/ccmd/arithmetic_eval)
+    command](../../syntax/ccmd/arithmetic_eval.md)
 -   [Introduction to expansion and
-    substitution](/syntax/expansion/intro)
+    substitution](../../syntax/expansion/intro.md)
 -   [POSIX
     definition](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_04)

--- a/docs/syntax/expansion/brace.md
+++ b/docs/syntax/expansion/brace.md
@@ -40,7 +40,7 @@ instance, when embedded inside a for loop :
 `for i in $(eval echo {$a..$b})` This requires that the entire command
 be properly escaped to avoid unexpected expansions. If the sequence
 expansion is to be assigned to an array, another method is possible
-using [declaration commands](/commands/builtin/declare):
+using [declaration commands](../../commands/builtin/declare.md):
 `declare -a 'pics=(img{'"$a..$b"'}.png)'; mv "${pics[@]}" ../imgs` This
 is significantly safer, but one must still be careful to control the
 values of \$a and \$b. Both the exact quoting, and explicitly including
@@ -269,4 +269,4 @@ letter-ranges:
 ## See also
 
 -   [Introduction to expansion and
-    substitution](/syntax/expansion/intro)
+    substitution](../../syntax/expansion/intro.md)

--- a/docs/syntax/expansion/cmdsubst.md
+++ b/docs/syntax/expansion/cmdsubst.md
@@ -14,8 +14,8 @@ All **trailing** newlines are removed (below is an example for a
 workaround).
 
 In later steps, **if not quoted**, the results undergo [word
-splitting](/syntax/expansion/wordsplit) and [pathname
-expansion](/syntax/expansion/globs). You have to remember that, because
+splitting](../../syntax/expansion/wordsplit.md) and [pathname
+expansion](../../syntax/expansion/globs.md). You have to remember that, because
 the word splitting will also remove embedded newlines and other `IFS`
 characters and break the results up into several words. Also you\'ll
 probably get unexpected pathname matches. **If you need the literal
@@ -25,14 +25,14 @@ The second form `` `COMMAND` `` is more or less obsolete for Bash, since
 it has some trouble with nesting (\"inner\" backticks need to be
 escaped) and escaping characters. Use `$(COMMAND)`, it\'s also POSIX!
 
-When you [call an explicit subshell](/syntax/ccmd/grouping_subshell)
+When you [call an explicit subshell](../../syntax/ccmd/grouping_subshell.md)
 `(COMMAND)` inside the command substitution `$()`, then take care, this
 way is **wrong**:
 
     $((COMMAND))
 
 Why? because it collides with the syntax for [arithmetic
-expansion](/syntax/expansion/arith). You need to separate the command
+expansion](../../syntax/expansion/arith.md). You need to separate the command
 substitution from the inner `(COMMAND)`:
 
     $( (COMMAND) )
@@ -134,5 +134,5 @@ commands\' output with its trailing newlines.
 ## See also
 
 -   Internal: [Introduction to expansion and
-    substitution](/syntax/expansion/intro)
--   Internal: [Obsolete and deprecated syntax](/scripting/obsolete)
+    substitution](../../syntax/expansion/intro.md)
+-   Internal: [Obsolete and deprecated syntax](../../scripting/obsolete.md)

--- a/docs/syntax/expansion/globs.md
+++ b/docs/syntax/expansion/globs.md
@@ -11,16 +11,16 @@ matching `*.log`):
     grep "changes:" *.log
 
 The base syntax for the pathname expansion is the [pattern
-matching](/syntax/pattern) syntax. The pattern you describe is matched
+matching](../../syntax/pattern.md) syntax. The pattern you describe is matched
 against all existing filenames and the matching ones are substituted.
 Since this substitution happens **after [word
-splitting](/syntax/expansion/wordsplit)**, all resulting filenames are
+splitting](../../syntax/expansion/wordsplit.md)**, all resulting filenames are
 literal and treated as separate words, no matter how many spaces or
 other `IFS`-characters they contain.
 
 ## Normal behaviour
 
--   with [the set command](/commands/builtin/set) (`-f`, `noglob`) you
+-   with [the set command](../../commands/builtin/set.md) (`-f`, `noglob`) you
     can entirely disable pathname expansion
 -   when matching a pathname, the slash-character (`/`) always needs to
     be matched explicitly
@@ -49,7 +49,7 @@ other `IFS`-characters they contain.
     globs (e.g. `[A-Z]`) use C locale order rather than the configured
     locale\'s order (i.e. `ABC...abc...` instead of e.g. `AaBbCc...`) -
     since 4.3-alpha
--   the variable [GLOBIGNORE](/syntax/shellvars#GLOBIGNORE) can be set
+-   the variable [GLOBIGNORE](../../syntax/shellvars.md#GLOBIGNORE) can be set
     to a colon-separated list of patterns to be removed from the list
     before it is returned
 
@@ -66,7 +66,7 @@ In this example, no files matched the pattern, so the glob was left
 intact (a literal asterisk, followed by dot-txt).
 
 This can be very annoying, for example when you drive a
-[for-loop](/syntax/ccmd/classic_for) using the pathname expansion:
+[for-loop](../../syntax/ccmd/classic_for.md) using the pathname expansion:
 
     for filename in *.txt; do
       echo "=== BEGIN: $filename ==="
@@ -107,8 +107,8 @@ followed by two numbers, followed by at least 3 more characters:
 ## See also
 
 -   [Introduction to expansion and
-    substitution](/syntax/expansion/intro)
--   [pattern matching syntax](/syntax/pattern)
--   [the set builtin command](/commands/builtin/set)
--   [the shopt builtin command](/commands/builtin/shopt)
--   [list of shell options](/internals/shell_options)
+    substitution](../../syntax/expansion/intro.md)
+-   [pattern matching syntax](../../syntax/pattern.md)
+-   [the set builtin command](../../commands/builtin/set.md)
+-   [the shopt builtin command](../../commands/builtin/shopt.md)
+-   [list of shell options](../../internals/shell_options.md)

--- a/docs/syntax/expansion/intro.md
+++ b/docs/syntax/expansion/intro.md
@@ -21,7 +21,7 @@ see `Hello world`, not the variable or anything else!
 
 After all these expansions and substitutions are done, all quotes that
 are not meant literally (i.e., [the quotes that marked contiguous
-words](/syntax/quoting), as part of the shell syntax) are removed from
+words](../../syntax/quoting.md), as part of the shell syntax) are removed from
 the commandline text, so the called program won\'t see them. This step
 is called **quote-removal**.
 
@@ -30,28 +30,28 @@ is called **quote-removal**.
 Saw a possible expansion syntax but don\'t know what it is? Here\'s a
 small list.
 
--   [Parameter expansion](/syntax/pe) (it has its own [overview
-    section](/syntax/pe#overview))
+-   [Parameter expansion](../../syntax/pe.md) (it has its own [overview
+    section](../../syntax/pe.md#overview))
     -   `$WORD`
     -   `${STUFF...}`
--   [Pathname expansion](/syntax/expansion/globs)
+-   [Pathname expansion](../../syntax/expansion/globs.md)
     -   `*.txt`
     -   `page_1?.html`
--   [Arithmetic expansion](/syntax/expansion/arith)
+-   [Arithmetic expansion](../../syntax/expansion/arith.md)
     -   `$(( EXPRESSION ))`
     -   `$[ EXPRESSION ]`
--   [Command substitution](/syntax/expansion/cmdsubst)
+-   [Command substitution](../../syntax/expansion/cmdsubst.md)
     -   `$( COMMAND )`
     -   `` ` COMMAND ` ``
--   [Tilde expansion](/syntax/expansion/tilde)
+-   [Tilde expansion](../../syntax/expansion/tilde.md)
     -   `~`
     -   `~+`
     -   `~-`
--   [Brace expansion](/syntax/expansion/brace)
+-   [Brace expansion](../../syntax/expansion/brace.md)
     -   `{X,Y,Z}`
     -   `{X..Y}`
     -   `{X..Y..Z}`
--   [Process substitution](/syntax/expansion/proc_subst)
+-   [Process substitution](../../syntax/expansion/proc_subst.md)
     -   `<( COMMAND )`
     -   `>( COMMAND )`
 
@@ -64,25 +64,25 @@ splitting!).
 
 The order is (from first to last):
 
--   [Brace expansion](/syntax/expansion/brace)
--   [Tilde expansion](/syntax/expansion/tilde)
+-   [Brace expansion](../../syntax/expansion/brace.md)
+-   [Tilde expansion](../../syntax/expansion/tilde.md)
 -   The following expansions happen at the same time, in a left-to-right
     fashion on the commandline (see below)
-    -   [Parameter expansion](/syntax/pe)
-    -   [Arithmetic expansion](/syntax/expansion/arith)
-    -   [Command substitution](/syntax/expansion/cmdsubst)
--   [Word splitting](/syntax/expansion/wordsplit)
--   [Pathname expansion](/syntax/expansion/globs)
+    -   [Parameter expansion](../../syntax/pe.md)
+    -   [Arithmetic expansion](../../syntax/expansion/arith.md)
+    -   [Command substitution](../../syntax/expansion/cmdsubst.md)
+-   [Word splitting](../../syntax/expansion/wordsplit.md)
+-   [Pathname expansion](../../syntax/expansion/globs.md)
 
-[Process substitution](/syntax/expansion/proc_subst) is performed
-**simultaneously** with [parameter expansion](/syntax/pe), [command
-substitution](/syntax/expansion/cmdsubst) and [arithmetic
-expansion](/syntax/expansion/arith). It is only performed when the
+[Process substitution](../../syntax/expansion/proc_subst.md) is performed
+**simultaneously** with [parameter expansion](../../syntax/pe.md), [command
+substitution](../../syntax/expansion/cmdsubst.md) and [arithmetic
+expansion](../../syntax/expansion/arith.md). It is only performed when the
 underlying operating system supports it.
 
-The 3 steps [parameter expansion](/syntax/pe), [arithmetic
-expansion](/syntax/expansion/arith) and [command
-substitution](/syntax/expansion/cmdsubst) happen at the same time in a
+The 3 steps [parameter expansion](../../syntax/pe.md), [arithmetic
+expansion](../../syntax/expansion/arith.md) and [command
+substitution](../../syntax/expansion/cmdsubst.md) happen at the same time in a
 left-to-right fashion on nthe commandline. This means
 
     i=1

--- a/docs/syntax/expansion/proc_subst.md
+++ b/docs/syntax/expansion/proc_subst.md
@@ -10,11 +10,11 @@ of a process (some sequence of commands) appear as a temporary file.
     >( <LIST> )
 
 Process substitution is performed **simultaneously** with [parameter
-expansion](/syntax/pe), [command
-substitution](/syntax/expansion/cmdsubst) and [arithmetic
-expansion](/syntax/expansion/arith).
+expansion](../../syntax/pe.md), [command
+substitution](../../syntax/expansion/cmdsubst.md) and [arithmetic
+expansion](../../syntax/expansion/arith.md).
 
-The [command list](/syntax/basicgrammar#lists) `<LIST>` is executed and
+The [command list](../../syntax/basicgrammar.md#lists) `<LIST>` is executed and
 its
 
 -   standard output filedescriptor in the `<( ... )` form or
@@ -126,7 +126,7 @@ echo "$counter files"
 This is the normal input file redirection `< FILE`, just that the `FILE`
 in this case is the result of process substitution. It\'s important to
 note that the space is required in order to disambiguate the syntax from
-[here documents](/syntax/redirection#here_documents).
+[here documents](../../syntax/redirection.md#here_documents).
 
 ``` bash
 : < <(COMMAND) # Good.
@@ -158,7 +158,7 @@ See the above section on [#scope](#scope)
     not (yet) pdksh derivatives (mksh). Coprocesses may be used instead.
 -   Process substitution is supported only on systems that support
     either named pipes (FIFO - a [special
-    file](/dict/terms/special_file)) or the `/dev/fd/*` method for
+    file](../../dict/terms/special_file.md)) or the `/dev/fd/*` method for
     accessing open files. If the system doesn\'t support `/dev/fd/*`,
     Bash falls back to creating named pipes. Note that not all shells
     that support process substitution have that fallback.
@@ -178,7 +178,7 @@ ${dev[${dev='dev[1>(${dev[dev]})]'}]}
 ## See also
 
 -   Internal: [Introduction to expansion and
-    substitution](/syntax/expansion/intro)
--   Internal: [Bash in the process tree](/scripting/processtree)
+    substitution](../../syntax/expansion/intro.md)
+-   Internal: [Bash in the process tree](../../scripting/processtree.md)
     (subshells)
--   Internal: [Redirection](/syntax/redirection)
+-   Internal: [Redirection](../../syntax/redirection.md)

--- a/docs/syntax/expansion/tilde.md
+++ b/docs/syntax/expansion/tilde.md
@@ -42,7 +42,7 @@ Tilde expansion is also performed everytime a variable is assigned:
 I don\'t know yet, if this is a bug or intended. \</note\>
 
 This way you can correctly use the tilde expansion in your
-[PATH](/syntax/shellvars#PATH):
+[PATH](../../syntax/shellvars.md#PATH):
 
     PATH=~/mybins:~peter/mybins:$PATH
 
@@ -68,7 +68,7 @@ operating system for the associated home directory for `<NAME>`.
 To find the home directory of the current user (`~`), Bash has a
 precedence:
 
--   expand to the value of [HOME](/syntax/shellvars#HOME) if it\'s
+-   expand to the value of [HOME](../../syntax/shellvars.md#HOME) if it\'s
     defined
 -   expand to the home directory of the user executing the shell
     (operating system)
@@ -80,7 +80,7 @@ directory, at least regarding tilde expansion.
 
     ~+
 
-This expands to the value of the [PWD](/syntax/shellvars#PWD) variable,
+This expands to the value of the [PWD](../../syntax/shellvars.md#PWD) variable,
 which holds the currect working directory:
 
     echo "CWD is $PWD"
@@ -93,7 +93,7 @@ is equivalent to (note it **must** be a separate word!):
 
     ~-
 
-This expands to the value of the [OLDPWD](/syntax/shellvars#OLDPWD)
+This expands to the value of the [OLDPWD](../../syntax/shellvars.md#OLDPWD)
 variable, which holds the previous working directory (the one before the
 last `cd`). If `OLDPWD` is unset (never changed the directory), it is
 not expanded.
@@ -107,4 +107,4 @@ not expanded.
 ## See also
 
 -   Internal: [Introduction to expansion and
-    substitution](/syntax/expansion/intro)
+    substitution](../../syntax/expansion/intro.md)

--- a/docs/syntax/expansion/wordsplit.md
+++ b/docs/syntax/expansion/wordsplit.md
@@ -5,9 +5,9 @@ FIXME to be continued!
 Word splitting occurs once any of the following expansions are done (and
 only then!)
 
--   [Parameter expansion](/syntax/pe)
--   [Command substitution](/syntax/expansion/cmdsubst)
--   [Arithmetic expansion](/syntax/expansion/arith)
+-   [Parameter expansion](../../syntax/pe.md)
+-   [Command substitution](../../syntax/expansion/cmdsubst.md)
+-   [Arithmetic expansion](../../syntax/expansion/arith.md)
 
 Bash will scan the results of these expansions for special `IFS`
 characters that mark word boundaries. This is only done on results that
@@ -44,8 +44,8 @@ is solely responsible.
 ## See also
 
 -   [Introduction to expansion and
-    substitution](/syntax/expansion/intro)
--   [Quoting and escaping](/syntax/quoting)
+    substitution](../../syntax/expansion/intro.md)
+-   [Quoting and escaping](../../syntax/quoting.md)
 -   [WordSplitting](http://mywiki.wooledge.org/WordSplitting),
     [IFS](http://mywiki.wooledge.org/IFS), and
     [DontReadLinesWithFor](http://mywiki.wooledge.org/DontReadLinesWithFor) -

--- a/docs/syntax/grammar/parser_exec.md
+++ b/docs/syntax/grammar/parser_exec.md
@@ -4,7 +4,7 @@ FIXME work in progress\...
 
 ![](keywords>bash shell scripting syntax language behaviour executing execution)
 
-Nearly everything in [Bash grammar](/syntax/basicgrammar) can be broken
+Nearly everything in [Bash grammar](../../syntax/basicgrammar.md) can be broken
 down to a \"simple command\". The only thing Bash has to expand,
 evaluate and execute is the simple command.
 
@@ -27,16 +27,16 @@ the simple command **from left to right**):
     -   variable assignments precede the command name and have the form
         `WORD=WORD`
     -   redirections can appear anywhere in the simple command
-2.  The rest of the words are [expanded](/syntax/expansion/intro). If
+2.  The rest of the words are [expanded](../../syntax/expansion/intro.md). If
     any words remain after expansion, the first word is taken to be the
     **name of the command** and the remaining words are the
     **arguments**.
-3.  [Redirections](/syntax/redirection) are performed.
+3.  [Redirections](../../syntax/redirection.md) are performed.
 4.  The text after the `=` in each variable assignment undergoes [tilde
-    expansion](/syntax/expansion/tilde), [parameter
-    expansion](/syntax/pe), [command
-    substitution](/syntax/expansion/cmdsubst), [arithmetic
-    expansion](/syntax/expansion/arith), and quote removal before being
+    expansion](../../syntax/expansion/tilde.md), [parameter
+    expansion](../../syntax/pe.md), [command
+    substitution](../../syntax/expansion/cmdsubst.md), [arithmetic
+    expansion](../../syntax/expansion/arith.md), and quote removal before being
     assigned to the variable.
 
 If **no command name** results after expansion:
@@ -120,6 +120,6 @@ FIXME to be continued
 
 ## See also
 
--   Internal: [Redirection](/syntax/redirection)
+-   Internal: [Redirection](../../syntax/redirection.md)
 -   Internal: [Introduction to expansions and
-    substitutions](/syntax/expansion/intro)
+    substitutions](../../syntax/expansion/intro.md)

--- a/docs/syntax/keywords/coproc.md
+++ b/docs/syntax/keywords/coproc.md
@@ -18,7 +18,7 @@ The process ID of the shell spawned to execute the coprocess is
 available through the value of the variable named by `NAME` followed by
 a `_PID` suffix. For example, the variable name used to store the PID of
 a coproc started with no `NAME` given would be `COPROC_PID` (because
-`COPROC` is the default `NAME`). [wait](/commands/builtin/wait) may be
+`COPROC` is the default `NAME`). [wait](../../commands/builtin/wait.md) may be
 used to wait for the coprocess to terminate. Additionally, coprocesses
 may be manipulated through their `jobspec`.
 


### PR DESCRIPTION
```bash
find docs/ -depth 3  -name '*.md' | xargs grep '(.*/' -l | \
  xargs -I{} \
  sed -i '' \
  -e 's%(/\([^/#).][^/#).]*\)/\([^/#).][^/#).]*\)\(.md\)\{0\})%(../../\1/\2.md)%g' \
  -e 's%(/\([^/#).][^/#).]*\)/\([^/#).][^/#).]*\)#\([a-zA-Z_-][0-9a-zA-Z_-]*\))%(../../\1/\2.md#\3)%g' \
  -e 's%(/\([^/#).][^/#).]*\)/\([^/#).][^/#).]*\)/\([^/#).][^/#).]*\)\(.md\)\{0\})%(../../\1/\2/\3.md)%g' \
  -e 's%(/\([^/#).][^/#).]*\)/\([^/#).][^/#).]*\)/\([^/#).][^/#).]*\)#\([a-zA-Z_-][0-9a-zA-Z_-]*\))%(../../\1/\2/\3.md#\4)%g' \
  -e 's%](\([^:.>)#][^:.>)#]*\))%](../../\1.md)%g' \
  -e 's%](\([^:.>)#][^:.>)#]*\)#\([^:.>)#][^:.>)#]*\))%](../../\1.md#\2)%g' \
  {}
```

Related to https://github.com/flokoe/bash-hackers-wiki/issues/10

Testing:

I've cherry picked the three pull requests to my main branch, which should support hyperlink navigation among pages as long as the pages or markers exist:

  https://github.com/hansonchar/bash-hackers-wiki/tree/main/docs